### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -72,6 +72,8 @@ jobs:
   build:
     needs: E2E
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: ✅ Just to say i am ok
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/yoonghan/yoonghan.github.io/security/code-scanning/6](https://github.com/yoonghan/yoonghan.github.io/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the `build` job in the workflow file. Since the job does not interact with GitHub resources, the minimal permission `contents: read` is sufficient. This change ensures that the `GITHUB_TOKEN` used in the job adheres to the principle of least privilege.

The fix involves editing the `.github/workflows/pull-request.yml` file and adding the `permissions` block to the `build` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
