### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -58,6 +58,8 @@ jobs:
   PostApprove:
     needs: Approve
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: 🔎 Check for new commit.
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/yoonghan/yoonghan.github.io/security/code-scanning/5](https://github.com/yoonghan/yoonghan.github.io/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the `PostApprove` job. Since the job only runs a shell script and does not interact with the repository or other GitHub resources, it does not require any write permissions. The minimal permission required is `contents: read`, which allows the job to read the repository contents if needed.

The `permissions` block should be added directly under the `PostApprove` job definition, specifying `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
